### PR TITLE
feat(netlify-cms-widget-relation): revert to current relation behavior

### DIFF
--- a/packages/netlify-cms-core/src/backend.js
+++ b/packages/netlify-cms-core/src/backend.js
@@ -278,6 +278,7 @@ class Backend {
     const entries = await this.listAllEntries(collection);
     const hits = fuzzy
       .filter(searchTerm, entries, { extract: extractSearchFields(searchFields) })
+      .filter(entry => entry.score > 5)
       .sort(sortByScore)
       .map(f => f.original);
     return { query: searchTerm, hits };


### PR DESCRIPTION
Thanks for starting this whole `react-select` migration! 🎉 

I figured out we should try to keep `relation` as backwards compatible as possible, also in behavior, as it's not a major release. as you've implemented I'm worried a bit about larger datasets.

It's awesome on smaller ones, as It feels snappy, no loadings, but maybe that should be a `preload` option on the field? (I didn't implement that yet. just reverted, and "remixed" it to make my life easier when integrating the custom UI/"data-hydration")

| ![3 mov](https://user-images.githubusercontent.com/8649362/49694404-a6e90c80-fb70-11e8-87bc-c37c9168400e.gif) |
|---|
| Also got the loading indicator working, not sure if was intentional to keep it off. |


> **PS**: Sorry for doing a PR on top of yours, but it seemed appropriate as we are working towards a common goal (:
